### PR TITLE
Add Freeswitch Docker image

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -7,6 +7,7 @@ BUILD_INFR="YES"
 BUILD_CONTROL="YES"
 BUILD_CONTENTSTORE="YES"
 BUILD_SCHEDULER="YES"
+BUILD_FREESWITCH="YES"
 TAG_LATEST="YES"
 TAG_PREFIX=""
 EXTRA_RUNARGS=""
@@ -36,6 +37,9 @@ while [[ $# > 0 ]]; do
             ;;
         --no-scheduler)
             BUILD_SCHEDULER="NO"
+            ;;
+        --no-freeswitch)
+            BUILD_FREESWITCH="NO"
             ;;
         --no-latest)
             TAG_LATEST="NO"
@@ -168,6 +172,11 @@ fi
 if [ "$BUILD_SCHEDULER" = "YES" ]; then
     echo "Building scheduler image..."
     mkimage mama-ng-scheduler $SCHEDULER_DIR Dockerfile
+fi
+
+if [ "$BUILD_FREESWITCH" = "YES" ]; then
+    echo "Building freeswitch image..."
+    mkimage freeswitch $BASE_DIR/freeswitch Dockerfile
 fi
 
 echo "Done."

--- a/freeswitch/Dockerfile
+++ b/freeswitch/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
 
 # Copy basic configuration files
 RUN cp -a /usr/share/freeswitch/conf/vanilla/. /etc/freeswitch/
+COPY config/ /etc/freeswitch/
 
 # Don't expose any ports - use host networking
 

--- a/freeswitch/Dockerfile
+++ b/freeswitch/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:jessie
+MAINTAINER Praekelt Foundation <dev@praekeltfoundation.org>
+
+# Add Freeswitch 1.6 repo
+RUN echo "deb http://files.freeswitch.org/repo/deb/freeswitch-1.6/ jessie main" > /etc/apt/sources.list.d/freeswitch.list \
+    && apt-key adv --keyserver pool.sks-keyservers.net --recv-key D76EDC7725E010CF
+
+# Install Freeswitch (use regular apt-get install to avoid weird dependency problems)
+RUN apt-get update \
+    && apt-get -qy install \
+        freeswitch-meta-vanilla \
+        freeswitch-mod-flite \
+        freeswitch-mod-shout \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy basic configuration files
+RUN cp -a /usr/share/freeswitch/conf/vanilla/. /etc/freeswitch/
+
+# Don't expose any ports - use host networking
+
+# Run Freeswitch
+CMD stdbuf -i0 -o0 -e0 /usr/bin/freeswitch -c

--- a/freeswitch/config/autoload_configs/modules.conf.xml
+++ b/freeswitch/config/autoload_configs/modules.conf.xml
@@ -1,0 +1,139 @@
+<configuration name="modules.conf" description="Modules">
+  <modules>
+    
+    <!-- Loggers (I'd load these first) -->
+    <load module="mod_console"/>
+    <!-- <load module="mod_graylog2"/> -->
+    <load module="mod_logfile"/>
+    <!-- <load module="mod_syslog"/> -->
+
+    <!--<load module="mod_yaml"/>-->
+
+    <!-- Multi-Faceted -->
+    <!-- mod_enum is a dialplan interface, an application interface and an api command interface -->
+    <load module="mod_enum"/>
+
+    <!-- XML Interfaces -->
+    <!-- <load module="mod_xml_rpc"/> -->
+    <!-- <load module="mod_xml_curl"/> -->
+    <!-- <load module="mod_xml_cdr"/> -->
+    <!-- <load module="mod_xml_scgi"/> -->
+
+    <!-- Event Handlers -->
+    <load module="mod_cdr_csv"/>
+    <!-- <load module="mod_cdr_sqlite"/> -->
+    <!-- <load module="mod_event_multicast"/> -->
+    <load module="mod_event_socket"/>
+    <!-- <load module="mod_event_zmq"/> -->
+    <!-- <load module="mod_zeroconf"/> -->
+    <!-- <load module="mod_erlang_event"/> -->
+    <!-- <load module="mod_snmp"/> -->
+
+    <!-- Directory Interfaces -->
+    <!-- <load module="mod_ldap"/> -->
+
+    <!-- Endpoints -->
+    <!-- <load module="mod_dingaling"/> -->
+    <!-- <load module="mod_portaudio"/> -->
+    <!-- <load module="mod_alsa"/> -->
+    <load module="mod_sofia"/>
+    <load module="mod_loopback"/>
+    <!-- <load module="mod_woomera"/> -->
+    <!-- <load module="mod_freetdm"/> -->
+    <!-- <load module="mod_unicall"/> -->
+    <!-- <load module="mod_skinny"/> -->
+    <!-- <load module="mod_khomp"/>   -->
+    <!-- <load module="mod_rtmp"/>   -->
+    <load module="mod_rtc"/>
+    <load module="mod_verto"/>
+
+    <!-- Applications -->
+    <load module="mod_commands"/>
+    <load module="mod_conference"/>
+    <!-- <load module="mod_curl"/> -->
+    <load module="mod_db"/>
+    <load module="mod_dptools"/>
+    <load module="mod_expr"/>
+    <load module="mod_fifo"/>
+    <load module="mod_hash"/>
+    <!--<load module="mod_mongo"/> -->
+    <load module="mod_voicemail"/>
+    <!--<load module="mod_directory"/>-->
+    <!--<load module="mod_distributor"/>-->
+    <!--<load module="mod_lcr"/>-->
+    <!--<load module="mod_easyroute"/>-->
+    <load module="mod_esf"/>
+    <load module="mod_fsv"/>
+    <!--<load module="mod_cluechoo"/>-->
+    <load module="mod_valet_parking"/>
+    <!--<load module="mod_fsk"/>-->
+    <!--<load module="mod_spy"/>-->
+    <!--<load module="mod_random"/>-->
+    <load module="mod_httapi"/>
+    <!--<load module="mod_translate"/>-->
+
+    <!-- SNOM Module -->
+    <!--<load module="mod_snom"/>-->
+
+    <!-- This one only works on Linux for now -->
+    <!--<load module="mod_ladspa"/>-->
+
+    <!-- Dialplan Interfaces -->
+    <!-- <load module="mod_dialplan_directory"/> -->
+    <load module="mod_dialplan_xml"/>
+    <load module="mod_dialplan_asterisk"/>
+
+    <!-- Codec Interfaces -->
+    <load module="mod_spandsp"/>
+    <load module="mod_g723_1"/>
+    <load module="mod_g729"/>
+    <load module="mod_amr"/>
+    <!--<load module="mod_ilbc"/>-->
+    <load module="mod_h26x"/>
+    <load module="mod_vp8"/>
+    <load module="mod_b64"/>
+    <!--<load module="mod_siren"/>-->
+    <!--<load module="mod_isac"/>-->
+    <!--<load module="mod_celt"/>-->
+    <load module="mod_opus"/>
+
+    <!-- File Format Interfaces -->
+    <load module="mod_sndfile"/>
+    <load module="mod_native_file"/>
+    <!-- <load module="mod_shell_stream"/> -->
+    <!--For icecast/mp3 streams/files-->
+    <load module="mod_shout"/>
+    <!--For local streams (play all the files in a directory)-->
+    <load module="mod_local_stream"/>
+    <load module="mod_tone_stream"/>
+
+    <!-- Timers -->
+    <!-- <load module="mod_timerfd"/> -->
+    <!-- <load module="mod_posix_timer"/> -->
+
+    <!-- Languages -->
+    <!-- <load module="mod_v8"/> -->
+    <!-- <load module="mod_perl"/> -->
+    <!-- <load module="mod_python"/> -->
+    <!-- <load module="mod_java"/> -->
+    <load module="mod_lua"/>
+
+    <!-- ASR /TTS -->
+    <load module="mod_flite"/>
+    <!-- <load module="mod_pocketsphinx"/> -->
+    <!-- <load module="mod_cepstral"/> -->
+    <!-- <load module="mod_tts_commandline"/> -->
+    <!-- <load module="mod_rss"/> -->
+    
+    <!-- Say -->
+    <load module="mod_say_en"/>
+    <!-- <load module="mod_say_ru"/> -->
+    <!-- <load module="mod_say_zh"/> -->
+    <!-- <load module="mod_say_sv"/> -->
+
+    <!-- Third party modules -->
+    <!--<load module="mod_nibblebill"/>-->
+    <!--<load module="mod_callcenter"/>-->
+
+  </modules>
+</configuration>


### PR DESCRIPTION
Freeswitch packages are only available for Debian (and they are not Ubuntu-compatible).

Freeswitch has various problems running under Docker with standard bridge networking, but things should work better with host networking as individual ports do not need to be exposed. Using host networking makes it difficult to use the image under Marathon - such an image would rather be launched on a dedicated machine using supervisor.

This may be the easiest way to get Freeswitch running without having a Debian host. Additionally, we can package config with the image like we do for the other parts of the system.
