### PR TITLE
Add virtualenv bin directory to PATH of all run images

### DIFF
--- a/docker/go-metrics-api.dockerfile
+++ b/docker/go-metrics-api.dockerfile
@@ -1,5 +1,4 @@
 FROM mama-ng-run
 MAINTAINER Praekelt Foundation <dev@praekeltfoundation.org>
 
-RUN . /appenv/bin/activate && \
-    $PIP_INSTALL go-metrics-api
+RUN $PIP_INSTALL go-metrics-api

--- a/docker/jssandbox.dockerfile
+++ b/docker/jssandbox.dockerfile
@@ -9,5 +9,4 @@ ENV NODE_PATH=/node_modules
 
 ADD build/node_modules /node_modules
 
-RUN . /appenv/bin/activate && \
-    $PIP_INSTALL vxsandbox
+RUN $PIP_INSTALL vxsandbox

--- a/docker/mama-ng-contentstore.dockerfile
+++ b/docker/mama-ng-contentstore.dockerfile
@@ -7,5 +7,4 @@ RUN apt-get update \
 
 ADD build/mama-ng-contentstore-static /static
 
-RUN . /appenv/bin/activate && \
-    $PIP_INSTALL mama-ng-contentstore
+RUN $PIP_INSTALL mama-ng-contentstore

--- a/docker/mama-ng-control.dockerfile
+++ b/docker/mama-ng-control.dockerfile
@@ -7,5 +7,4 @@ RUN apt-get update \
 
 ADD build/mama-ng-control-static /static
 
-RUN . /appenv/bin/activate && \
-    $PIP_INSTALL mama-ng-control
+RUN $PIP_INSTALL mama-ng-control

--- a/docker/mama-ng-run.dockerfile
+++ b/docker/mama-ng-run.dockerfile
@@ -1,5 +1,8 @@
 FROM mama-ng-base
 
+ENV PATH="/appenv/bin:$PATH"
+RUN . /appenv/bin/activate
+
 ADD build/wheelhouse /wheelhouse
 
 ENV PIP_INSTALL="pip install --no-index -f wheelhouse"

--- a/docker/mama-ng-run.dockerfile
+++ b/docker/mama-ng-run.dockerfile
@@ -1,7 +1,6 @@
 FROM mama-ng-base
 
 ENV PATH="/appenv/bin:$PATH"
-RUN . /appenv/bin/activate
 
 ADD build/wheelhouse /wheelhouse
 

--- a/docker/vumi-http-api.dockerfile
+++ b/docker/vumi-http-api.dockerfile
@@ -1,5 +1,4 @@
 FROM mama-ng-run
 MAINTAINER Praekelt Foundation <dev@praekeltfoundation.org>
 
-RUN . /appenv/bin/activate && \
-    $PIP_INSTALL vumi-http-api
+RUN $PIP_INSTALL vumi-http-api

--- a/docker/vumi.dockerfile
+++ b/docker/vumi.dockerfile
@@ -1,5 +1,4 @@
 FROM mama-ng-run
 MAINTAINER Praekelt Foundation <dev@praekeltfoundation.org>
 
-RUN . /appenv/bin/activate && \
-    $PIP_INSTALL vumi
+RUN $PIP_INSTALL vumi

--- a/docker/vxfreeswitch.dockerfile
+++ b/docker/vxfreeswitch.dockerfile
@@ -1,5 +1,4 @@
 FROM mama-ng-run
 MAINTAINER Praekelt Foundation <dev@praekeltfoundation.org>
 
-RUN . /appenv/bin/activate && \
-    $PIP_INSTALL vxfreeswitch
+RUN $PIP_INSTALL vxfreeswitch


### PR DESCRIPTION
Mesos sets the entrypoint to every container as /bin/sh -c which results in us losing the virtualenv env vars. This means that binaries are not found.
