### PR TITLE
control/contentstore: Place static files in /app/static rather

### DIFF
--- a/docker/mama-ng-contentstore.dockerfile
+++ b/docker/mama-ng-contentstore.dockerfile
@@ -5,6 +5,6 @@ RUN apt-get update \
     && $APT_GET_INSTALL libpq5 \
     && rm -rf /var/lib/apt/lists/*
 
-ADD build/mama-ng-contentstore-static /static
+ADD build/mama-ng-contentstore-static /app/static
 
 RUN $PIP_INSTALL mama-ng-contentstore

--- a/docker/mama-ng-control.dockerfile
+++ b/docker/mama-ng-control.dockerfile
@@ -5,6 +5,6 @@ RUN apt-get update \
     && $APT_GET_INSTALL libpq5 \
     && rm -rf /var/lib/apt/lists/*
 
-ADD build/mama-ng-control-static /static
+ADD build/mama-ng-control-static /app/static
 
 RUN $PIP_INSTALL mama-ng-control


### PR DESCRIPTION
The processes are launched from the `/app` directory. Hopefully Django finds the files if they are in `/app/static`.
